### PR TITLE
use `printf` instead of `cat`

### DIFF
--- a/bulkrdl.sh
+++ b/bulkrdl.sh
@@ -1,15 +1,15 @@
 #!/bin/sh
 if ! [ -f shrdl.sh ]; then
-  printf "shrdl.sh not found.\n"
-  printf "make sure shrdl.sh in in the same directory as this script.\n"
-  exit 1
+    printf "shrdl.sh not found.\n"
+    printf "make sure to run this in the same directory as shrdl.sh.\n"
+    exit 1
 elif ! [ -f repolist.txt ]; then
-  printf "repolist.txt file not found.\n"
-  printf "Create a file in the same directory as this script containing the URLs for repos you want to download"
-  exit 1
+    printf "repolist.txt file not found.\n"
+    printf "Create a file in the current working directory called repolist.txt containing the URLs for repos you want to download"
+    exit 1
 fi
 
 while read -r line; do
-  printf "Downloading repo: %s\n" "$line"
-  ./shrdl.sh "$line"
+    printf "Downloading repo: %s\n" "$line"
+    ./shrdl.sh "$line"
 done < ./repolist.txt

--- a/shrdl.sh
+++ b/shrdl.sh
@@ -11,15 +11,13 @@ case $1 in
   ;;
 
   *)
-    cat << EOF
-shRDL - Downloads deb packages from Cydia repositories
+    printf "shRDL - Downloads deb packages from Cydia repositories
 
 Usage:
     shrdl.sh [URL]
 
     -h, --help          Print this message
-    -v, --version       Print version info
-EOF
+    -v, --version       Print version info\n"
     exit 0
   ;;
 esac

--- a/shrdl.sh
+++ b/shrdl.sh
@@ -22,10 +22,10 @@ for dep in curl gunzip bunzip2; do
     fi
 done
 
-if [ "$(curl -H "X-Machine: iPod4,1" -H "X-Unique-ID: 0000000000000000000000000000000000000000" -H "X-Firmware: 6.1" -H "User-Agent: Telesphoreo APT-HTTP/1.0.999" -w '%{http_code}' -L -s -o /dev/null "$1/Packages.gz")" -eq 200 ]; then
-    archive=gz
-elif [ "$(curl -H "X-Machine: iPod4,1" -H "X-Unique-ID: 0000000000000000000000000000000000000000" -H "X-Firmware: 6.1" -H "User-Agent: Telesphoreo APT-HTTP/1.0.999" -w '%{http_code}' -L -s -o /dev/null "$1/Packages.bz2")" -eq 200 ]; then
+if [ "$(curl -H "X-Machine: iPod4,1" -H "X-Unique-ID: 0000000000000000000000000000000000000000" -H "X-Firmware: 6.1" -H "User-Agent: Telesphoreo APT-HTTP/1.0.999" -w '%{http_code}' -L -s -o /dev/null "$1/Packages.bz2")" -eq 200 ]; then
     archive=bz2
+elif [ "$(curl -H "X-Machine: iPod4,1" -H "X-Unique-ID: 0000000000000000000000000000000000000000" -H "X-Firmware: 6.1" -H "User-Agent: Telesphoreo APT-HTTP/1.0.999" -w '%{http_code}' -L -s -o /dev/null "$1/Packages.gz")" -eq 200 ]; then
+    archive=gz
 else
     printf "Couldn't find a Packages file. Exiting\n"
     exit 1
@@ -39,10 +39,10 @@ rm -f urllist.txt
 
 curl -H "X-Machine: iPod4,1" -H "X-Unique-ID: 0000000000000000000000000000000000000000" -H "X-Firmware: 6.1" -H "User-Agent: Telesphoreo APT-HTTP/1.0.999" -L -# -O "$1/Packages.$archive"
 
-if [ "$archive" = "gz" ]; then
-    gunzip ./Packages.gz
-elif [ "$archive" = "bz2" ]; then
+if [ "$archive" = "bz2" ]; then
     bunzip2 ./Packages.bz2
+elif [ "$archive" = "gz" ]; then
+    gunzip ./Packages.gz
 fi
 
 while read -r line; do


### PR DESCRIPTION
faster and depends on less external binaries, small formatting changes.  The biggest change is not using curl to check for packages.gz if we already know packages.bz2 exists, which speeds things up a little